### PR TITLE
git-github: fix -n to -z

### DIFF
--- a/bin/git-github
+++ b/bin/git-github
@@ -6,7 +6,7 @@
 #   git-github [repo]
 #   
 
-if [[ -n $GITHUB_USER ]]; then
+if [[ -z $GITHUB_USER ]]; then
 	echo "\$GITHUB_USER is not defined."
 	exit 1
 fi


### PR DESCRIPTION
Should be checking to see if the provided `$GITHUB_USER` is an empty string. 

Probably a typo but in case someone else comes across this see bash [conditional expressions.](https://www.gnu.org/software/bash/manual/html_node/Bash-Conditional-Expressions.html)