### PR TITLE
Update keybindings.json

### DIFF
--- a/vscode/User/keybindings.json
+++ b/vscode/User/keybindings.json
@@ -106,10 +106,22 @@
     "when": "panelVisible && textInputFocus"
   },
   {
-    // Close panel when pressing Escape inside the search panel
+    "comment": "Closes panel when pressing Escape inside the Search panel",
     "key": "escape",
     "command": "workbench.action.closePanel",
-    "when": "panelFocus || terminalFocus"
+    "when": "activePanel == 'workbench.view.search' && panelFocus"
+  },
+  {
+    "comment": "Closes panel when pressing Escape inside the Problems panel",
+    "key": "escape",
+    "command": "workbench.action.closePanel",
+    "when": "activePanel == 'workbench.panel.markers' && panelFocus"
+  },
+  {
+    "comment": "Closes panel when pressing Escape inside the Integrated Terminal panel",
+    "key": "escape",
+    "command": "workbench.action.closePanel",
+    "when": "terminalFocus"
   },
 
   /*


### PR DESCRIPTION
This fixes the search box escape inside the Integrated Terminal.

## Problem

The current settings above have one drawback: when you try to search inside the terminal (Cmd+F) and then hide the search input by clicking a default `Esc`, the whole panel will be closed unexpectedly. 

![CleanShot 2024-04-22 at 18 28 46@2x](https://github.com/sapegin/dotfiles/assets/579331/b7cc6f99-4c2a-4ec4-9cf4-e4d56eaf1a4e)

