### PR TITLE
Wezterm preferences update

### DIFF
--- a/tilde/.wezterm.lua
+++ b/tilde/.wezterm.lua
@@ -98,6 +98,10 @@ config.window_frame = {
 	inactive_titlebar_bg = '#352a21',
 }
 
+-- Command Palette
+config.command_palette_rows = 7
+config.command_palette_font_size = 15
+
 -- Hot keys
 config.keys = {
 	-- Make Page up/down work

--- a/tilde/.wezterm.lua
+++ b/tilde/.wezterm.lua
@@ -202,6 +202,23 @@ config.keys = {
 		mods = 'OPT',
 		action = wezterm.action.DisableDefaultAssignment,
 	},
+
+	-- Rename tab title
+	{
+		key = 'R',
+		mods = 'CMD|SHIFT',
+		action = act.PromptInputLine {
+			description = 'Enter new name for tab',
+			action = wezterm.action_callback(function(window, _, line)
+				-- line will be `nil` if they hit escape without entering anything
+				-- An empty string if they just hit enter
+				-- Or the actual line of text they wrote
+				if line then
+					window:active_tab():set_title(line)
+				end
+			end),
+		},
+	},
 }
 
 -- Mouse
@@ -259,10 +276,18 @@ local function get_current_working_dir(tab)
 	or string.gsub(current_dir.file_path, '(.*[/\\])(.*)', '%2')
 end
 
--- Set tab title to the current working directory
+-- Set tab title to the one that was set via `tab:set_title()`
+-- or fall back to the current working directory as a title
 wezterm.on('format-tab-title', function(tab, tabs, panes, config, hover, max_width)
 	local index = tonumber(tab.tab_index) + 1
-	return string.format('  %s•%s  ', index, get_current_working_dir(tab))
+	local custom_title = tab.tab_title
+	local title = get_current_working_dir(tab)
+
+	if custom_title and #custom_title > 0 then
+		title = custom_title
+	end
+
+	return string.format('  %s•%s  ', index, title)
 end)
 
 -- Set window title to the current working directory


### PR DESCRIPTION
A follow-up to https://github.com/sapegin/squirrelsong/pull/9

The PR does the following:
1. Tweaks command palette look
2. Adds command to rename tabs and updates even handler to preserve custom tab title before falling back to the current working dir as a title
    1. Helpful when one tab represents a set of panes relating to one project, for example.