### PR TITLE
Add keybinding to open preferences files

### DIFF
--- a/tilde/.wezterm.lua
+++ b/tilde/.wezterm.lua
@@ -192,6 +192,22 @@ config.keys = {
 		action = wezterm.action.Search({ CaseInSensitiveString = '' }),
 	},
 
+	-- Open WezTerm config file quickly
+  {
+		key = ',',
+		mods = 'CMD',
+		action = act.SpawnCommandInNewTab {
+			cwd = os.getenv('WEZTERM_CONFIG_DIR'),
+			set_environment_variables = {
+				TERM = 'screen-256color',
+			},
+			args = {
+				'/Applications/CotEditor.app/Contents/MacOS/CotEditor',
+				os.getenv('WEZTERM_CONFIG_FILE'),
+			},
+		},
+	},
+
 	-- Disable some default hotkeys
 	{
 		key = 'Enter',


### PR DESCRIPTION
Suggesting a natural key binding to open Preferences inside CotEditor (_may be changed to suit personal tastes_). Hope you find it helpful 😏 